### PR TITLE
Added blank line below heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # roadmap
+
 Curriculum studied while learning web development


### PR DESCRIPTION
Markdown lint requires a blank line above and below a heading.